### PR TITLE
feat: 媒体上传冷启动自动解析 CdnManager, 重启后无需手动发图激活

### DIFF
--- a/docs/media-coldstart.md
+++ b/docs/media-coldstart.md
@@ -1,0 +1,70 @@
+# 媒体上传冷启动：CdnManager 自动解析
+
+> 2026-09 新增。解决"每次微信重启后必须手动发一张图片激活上传"的问题。
+
+## 问题
+
+`uploadGlobalX0`（图片/视频/语音上传、媒体下载共用的 `this` 指针）此前只能靠 hook
+捕获一次真实调用获得。微信重启后它是空的，必须有人在微信里手动发一张图，API 才能
+发媒体。这阻碍无人值守自动重启。
+
+## 原理（4.1.10.53 静态分析结论）
+
+`uploadGlobalX0` 是 `mars::cdn::CdnManager` 单例（mangled 类型名
+`N4mars3cdn10CdnManagerE`），由微信的服务定位器管理：
+
+```
+全局服务注册表 (std::map, __DATA,__common)
+  └─ GetService(std::string("default"))        ← cdnGetServiceAddr
+      └─ 按类型名 "N4mars3cdn10CdnManagerE" 取 ctx   ← cdnManagerGetterAddr
+          └─ [ctx + 0x40] = CdnManager 单例    ← 就是 uploadGlobalX0 / downloadGlobalX0
+```
+
+两个关键事实：
+
+1. **上传与下载是同一个对象**。上传分发链与下载分发链都调用同一个
+   `GetService("default")` + 同一个 getter，从同一上下文的 `+0x40` 取单例。
+   即 `uploadGlobalX0 === downloadGlobalX0`。
+2. **该单例在登录后、未发送任何图片时就已经注册在服务表里**。不需要"发一张图"
+   它才存在。但它是堆指针，每次进程重启都会变化，不能写死。
+
+## 修复（三层，任一生效即可用）
+
+1. **互回填**：上传/下载 hook 抓到任一指针时顺手赋给另一个（同一单例）
+2. **冷启动解析**：`ensureCdnManagerX0()` 兜底——手工构造 libc++ SSO 短字符串
+   `"default"`（24 字节缓冲：`+0` 写数据，`+0x17` 写长度），NativeFunction 依次调
+   `GetService` → getter → 读 `[ctx+0x40]`。失败自动回退老的报错路径
+3. 新 JSON 键用 `{{if}}` 条件渲染，**旧版本配置缺键不报错**，自动退回"hook 捕获"老行为
+
+## 新增 JSON 键
+
+| 键 | 含义 | 4.1.10.53 已确认值 |
+|---|---|---|
+| `cdnGetServiceAddr` | `GetService(std::string)` 服务定位器 | `0x4ca2130` |
+| `cdnManagerGetterAddr` | 按类型名取 CdnManager 上下文的 getter | `0x4e59dec` |
+
+`ctx+0x40` 的字段偏移写死在 `script.js`（跨版本一般稳定；若新版本解析失败需复核此偏移）。
+
+## 其他版本如何获取这两个地址（IDA）
+
+从每版本本来就要找的 `uploadImageAddr` 出发反追两步：
+
+1. 找 `uploadImageAddr` 的**唯一 BL 调用者**（包装函数；尾部特征
+   `mov x1, sp; mov x0, x19; bl uploadImageAddr`）
+2. 再找这个包装函数的**调用者**（分发函数；开头特征 `mov x20, x1; mov x19, x0`）
+3. 分发函数上部有两连发调用：
+   - 引用字符串 `"default"` 之后的 `bl X` → **X = cdnGetServiceAddr**
+   - 紧随其后、吃掉 X 返回值的 `bl Y` → **Y = cdnManagerGetterAddr**
+4. 交叉确认：Y 内部有一处 `adrp+ldr` 引用全局指针，指向字符串
+   `N4mars3cdn10CdnManagerE`
+
+反向入口更省事：在二进制里搜字符串 `N4mars3cdn10CdnManagerE` → 引用它的函数就是
+getter（Y）→ Y 的调用者即分发函数，里面紧挨着的另一个 `bl` 即 GetService（X）。
+
+## 验证记录（4.1.10.53，macOS arm64，gadget 模式）
+
+- 重启 onebot 后**不发任何图**，直接 API 发图：日志出现
+  `[+] 冷启动服务定位器解析 CdnManager: 0xb8946ef18`，发送成功（filehelper 与私聊各一次）
+- 重启 onebot 后给 bot 账号发一张图（微信自动下载）：日志出现
+  `[+] 下载hook回填 uploadGlobalX0: 0xb8946ef18`，且事后用该指针上传成功
+- 两条独立路径得到同一指针，互为印证

--- a/onebot/script.js
+++ b/onebot/script.js
@@ -73,6 +73,9 @@ function initAddresses() {
 
     uploadImageAddr = baseAddr.add({{.uploadImageAddr}});
     cndOnCompleteAddr = baseAddr.add({{.cndOnCompleteAddr}});
+    // 冷启动 CdnManager 解析(可选, 旧版本 JSON 无此键则保持 ptr(0), 走 hook 捕获老路)
+    {{if .cdnGetServiceAddr}}cdnGetServiceAddr = baseAddr.add({{.cdnGetServiceAddr}});{{end}}
+    {{if .cdnManagerGetterAddr}}cdnManagerGetterAddr = baseAddr.add({{.cdnManagerGetterAddr}});{{end}}
 
     uploadGetCallbackWrapperAddr = baseAddr.add({{.uploadGetCallbackWrapperAddr}});
     uploadGetCallbackWrapperFuncAddr = baseAddr.add({{.uploadGetCallbackWrapperFuncAddr}});
@@ -203,7 +206,71 @@ function sendDownloadChunks(dataPtr, dataLen, fileId, cdnUrl) {
 	}
 }
 
+// mars::cdn::CdnManager 单例解析: 上传(uploadGlobalX0)/下载(downloadGlobalX0)共用的 this。
+// 2026-09-02 静态分析 4.1.10: 上传/下载分发链(0x4e5a6e4/0x4e5a7f4)都走
+// GetService("default")[0x4ca2130] -> 按类型名 "N4mars3cdn10CdnManagerE" getter[0x4e59dec]
+// -> [ctx+0x40]。该单例登录后即注册进全局服务表, 不需要先发一张图片触发。
+function resolveCdnManager() {
+    if (cdnGetServiceAddr.equals(ptr(0)) || cdnManagerGetterAddr.equals(ptr(0))) {
+        return ptr(0);
+    }
+    try {
+        // libc++ SSO 短字符串: 数据在 +0, 长度写在 +0x17 (对照 wechat.dylib std::string ctor)
+        var strDefault = Memory.alloc(24);
+        strDefault.writeUtf8String("default");
+        strDefault.add(0x17).writeU8(7);
+
+        var getService = new NativeFunction(cdnGetServiceAddr, 'pointer', ['pointer']);
+        var svc = getService(strDefault);
+        if (!isReadablePointer(svc)) {
+            console.error("[!] GetService(\"default\") 返回不可读: " + svc);
+            return ptr(0);
+        }
+        var getCtx = new NativeFunction(cdnManagerGetterAddr, 'pointer', ['pointer']);
+        var ctx = getCtx(svc);
+        if (!isReadablePointer(ctx)) {
+            console.error("[!] CdnManager getter 返回不可读: " + ctx);
+            return ptr(0);
+        }
+        var mgr = readPointerIfReadable(ctx.add(0x40));
+        if (!isReadablePointer(mgr)) {
+            console.error("[!] ctx+0x40 管理器指针不可读: ctx=" + ctx);
+            return ptr(0);
+        }
+        return mgr;
+    } catch (e) {
+        console.error("[!] resolveCdnManager 异常: " + e);
+        return ptr(0);
+    }
+}
+
+// CdnManager 兜底: 1) hook 已捕获的互回填(同一单例) 2) 都没有则走服务定位器解析
+function ensureCdnManagerX0() {
+    if (uploadGlobalX0.equals(ptr(0)) && downloadGlobalX0) {
+        uploadGlobalX0 = downloadGlobalX0;
+        console.log("[+] downloadGlobalX0 回填 uploadGlobalX0: " + uploadGlobalX0);
+    }
+    if (!downloadGlobalX0 && !uploadGlobalX0.equals(ptr(0))) {
+        downloadGlobalX0 = uploadGlobalX0;
+        console.log("[+] uploadGlobalX0 回填 downloadGlobalX0: " + downloadGlobalX0);
+    }
+    if (uploadGlobalX0.equals(ptr(0))) {
+        var mgr = resolveCdnManager();
+        if (!mgr.equals(ptr(0))) {
+            uploadGlobalX0 = mgr;
+            if (!downloadGlobalX0) {
+                downloadGlobalX0 = mgr;
+            }
+            console.log("[+] 冷启动服务定位器解析 CdnManager: " + mgr);
+        }
+    }
+    return !uploadGlobalX0.equals(ptr(0));
+}
+
 function fillUploadX1AndStart(idAddr, pathAddr, x1Buffer, receiver, md5, filePath, payloadHex) {
+    if (uploadGlobalX0.equals(ptr(0))) {
+        ensureCdnManagerX0();
+    }
     if (uploadGlobalX0.equals(ptr(0))) {
         console.error("[!] uploadGlobalX0 尚未初始化，请等待 hook 捕获");
         return "fail";
@@ -260,6 +327,8 @@ var sendMsgType = "";
 var buf2RespAddr;
 
 var uploadImageAddr;
+var cdnGetServiceAddr = ptr(0);      // GetService(std::string) 服务定位器, 冷启动解析 CdnManager 用
+var cdnManagerGetterAddr = ptr(0);   // 按类型名 "N4mars3cdn10CdnManagerE" 取 ctx 的 getter
 var cndOnCompleteAddr;
 var imgMessageCallbackFunc;
 var videoMessageCallbackFunc;
@@ -812,6 +881,9 @@ function triggerUploadVideo(receiver, md5, videoPath, payloadHex) {
 
 function triggerUploadVoice(receiver, voicePath, payloadHex, audioDataHex, durationMs) {
     if (uploadGlobalX0.equals(ptr(0))) {
+        ensureCdnManagerX0();
+    }
+    if (uploadGlobalX0.equals(ptr(0))) {
         console.error("[!] uploadGlobalX0 尚未初始化，请等待 hook 捕获");
         return "fail";
     }
@@ -850,6 +922,11 @@ function attachUploadMedia() {
     Interceptor.attach(uploadImageAddr.add(0x10), {
         onEnter: function (args) {
 			uploadGlobalX0 = this.context.x0;
+			if (!downloadGlobalX0) {
+				// 上传/下载共用同一 mars::cdn::CdnManager 单例, 顺手回填
+				downloadGlobalX0 = this.context.x0;
+				console.log("[+] 上传hook回填 downloadGlobalX0: " + downloadGlobalX0);
+			}
 		}
     })
 }
@@ -1112,6 +1189,11 @@ function setReceiver() {
     Interceptor.attach(startDownloadMedia, {
         onEnter: function (args) {
             downloadGlobalX0 = this.context.x0;
+            if (uploadGlobalX0.equals(ptr(0))) {
+                // 上传/下载共用同一 mars::cdn::CdnManager 单例, 顺手回填
+                uploadGlobalX0 = this.context.x0;
+                console.log("[+] 下载hook回填 uploadGlobalX0: " + uploadGlobalX0);
+            }
             var fileIDAddr = readPointerIfReadable(this.context.x1.add(0x40));
             var fileId = readUtf8StringIfReadable(fileIDAddr);
             if (!fileId || !isReadablePointer(this.context.x1.add(0xA0))) {
@@ -1166,6 +1248,9 @@ function setReceiver() {
 
 // fileType:  HdImage => 1,Image => 2, thumbImage => 3, Video => 4, File => 5,
 function triggerDownload(receiver, cdnUrl, aesKey, filePath, fileType) {
+    if (!downloadGlobalX0) {
+        ensureCdnManagerX0();
+    }
     if (!downloadGlobalX0) {
         console.error("[!] downloadGlobalX0 尚未初始化，请等待 hook 捕获");
         return "fail";

--- a/wechat_version/4_1_10_53_mac.json
+++ b/wechat_version/4_1_10_53_mac.json
@@ -7,6 +7,8 @@
 	"autoBufferWriteFunc": "0x3AEDAC8",
 
 	"uploadImageAddr": "0x4e9c8d8",
+	"cdnGetServiceAddr": "0x4ca2130",
+	"cdnManagerGetterAddr": "0x4e59dec",
 	"cndOnCompleteAddr": "0x3A83AC0",
 	"uploadGetCallbackWrapperAddr": "0x4e5b67c",
 	"uploadGetCallbackWrapperFuncAddr": "0x3A8335C",


### PR DESCRIPTION
## 问题

每次微信重启后，`uploadGlobalX0` 为空，必须先**在微信里手动发一张图片**让 hook 捕获到指针，API 才能发送图片/视频/语音。这阻碍无人值守自动重启。

## 原因（4.1.10.53 arm64 静态分析）

`uploadGlobalX0` 是 `mars::cdn::CdnManager` 单例（mangled 名 `N4mars3cdn10CdnManagerE`），由微信的服务定位器管理：

```
全局服务注册表 (std::map)
  └─ GetService(std::string("default"))          ← cdnGetServiceAddr
      └─ 按类型名 "N4mars3cdn10CdnManagerE" 取 ctx   ← cdnManagerGetterAddr
          └─ [ctx + 0x40] = CdnManager 单例
```

两个关键事实：

1. **上传与下载是同一个对象**——上传分发链与下载分发链都走同一个 `GetService("default")` + 同一个 getter，从同一上下文 `+0x40` 取单例，即 `uploadGlobalX0 === downloadGlobalX0`
2. **该单例登录后即注册进服务表，不依赖任何图片发送**；但它是堆指针，每次进程重启都变化，不能写死

## 修复（三层，任一生效即可用）

1. **互回填**：上传/下载 hook 抓到任一指针时顺手赋给另一个（同一单例，日志可观测）
2. **冷启动解析**：`ensureCdnManagerX0()` 兜底——手工构造 libc++ SSO 短字符串 `"default"`（24 字节：`+0` 写数据、`+0x17` 写长度），NativeFunction 依次调 `GetService` → getter → 读 `[ctx+0x40]`，失败自动回退原有报错路径
3. 新 JSON 键用 `{{if}}` 条件渲染，**旧版本配置缺键不报错**，自动退回"hook 捕获"老行为

## ⚠️ 新增 JSON 键（其他版本需要补地址）

| 键 | 含义 | 4.1.10.53 已确认值 |
|---|---|---|
| `cdnGetServiceAddr` | `GetService(std::string)` 服务定位器 | `0x4ca2130` |
| `cdnManagerGetterAddr` | 按类型名取 CdnManager 上下文的 getter | `0x4e59dec` |

最新版本（如 4.1.11.53）获取方法见 **`docs/media-coldstart.md`**，速查：

- 反向入口最省事：在二进制里搜字符串 `N4mars3cdn10CdnManagerE` → 引用它的函数就是 `cdnManagerGetterAddr` → 它的调用者（分发函数）里紧挨着的另一个 `bl`（参数是字符串 `"default"`）就是 `cdnGetServiceAddr`
- 或从 `uploadImageAddr` 反追两步 BL 调用链（详见文档）

`ctx+0x40` 偏移写死在 script.js，跨版本一般稳定；新版本若解析失败需复核该偏移。**缺键时功能自动退回老行为，不影响现有版本使用。**

## 验证（4.1.10.53，macOS arm64，gadget 模式）

- 重启 onebot 后**不发任何图**直接 API 发图 → 日志 `[+] 冷启动服务定位器解析 CdnManager: 0xb8946ef18` → 发送成功（filehelper 与私聊各一次）
- 重启 onebot 后给 bot 发一张图（微信自动下载触发）→ 日志 `[+] 下载hook回填 uploadGlobalX0: 0xb8946ef18` → 用该指针上传成功
- 两条独立路径得到**同一指针**，互为印证

🤖 Generated with [Claude Code](https://claude.com/claude-code)